### PR TITLE
Update Python version requirement to <3.14

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -49,7 +49,7 @@ cuda-12 = [
     # CUDA 12, Python 3.13, Windows
     "onnxruntime-gpu @ https://files.pythonhosted.org/packages/c7/87/1361640e9277622591926f84d10fcc289c20be03e1ff5480d66c3cd2402f/onnxruntime_gpu-1.20.1-cp313-cp313-win_amd64.whl ; platform_system == 'Windows' and python_version == '3.13'",
     # CUDA 12, Python 3.13, Linux
-    "onnxruntime-gpu @ https://files.pythonhosted.org/packages/51/86/de1d7e513e178265e5fac8fd7fd529decd06416cbe316ce77a5b0ff6915b/onnxruntime_gpu-1.20.1-cp313-cp313-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl ; platform_system == 'Linux' and python_version == '3.13'",
+    "onnxruntime-gpu @ https://files.pythonhosted.org/packages/51/86/de1d7e513e178265e5fac8fd7fd529decd06416cbe316ce77a5b0ff6915b/onnxruntime_gpu-1.20.1-cp313-cp313-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl ; platform_system == 'Linux' and python_version == '3.13'"
 ]
 directml = [
     "onnxruntime-directml"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,7 @@ authors = [
     { name = "Ionite", email = "dev@ionite.io" }
 ]
 readme = "README.md"
-requires-python = ">=3.10,<3.13"
+requires-python = ">=3.10,<3.14"
 
 dependencies = [
     "Pillow",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -45,7 +45,11 @@ cuda-12 = [
     # CUDA 12, Python 3.12, Windows
     "onnxruntime-gpu @ https://aiinfra.pkgs.visualstudio.com/2692857e-05ef-43b4-ba9c-ccf1c22c437c/_packaging/9387c3aa-d9ad-4513-968c-383f6f7f53b8/pypi/download/onnxruntime-gpu/1.17.1/onnxruntime_gpu-1.17.1-cp312-cp312-win_amd64.whl ; platform_system == 'Windows' and python_version == '3.12'",
     # CUDA 12, Python 3.12, Linux
-    "onnxruntime-gpu @ https://aiinfra.pkgs.visualstudio.com/2692857e-05ef-43b4-ba9c-ccf1c22c437c/_packaging/9387c3aa-d9ad-4513-968c-383f6f7f53b8/pypi/download/onnxruntime-gpu/1.17.1/onnxruntime_gpu-1.17.1-cp312-cp312-manylinux_2_28_x86_64.whl ; platform_system == 'Linux' and python_version == '3.12'"
+    "onnxruntime-gpu @ https://aiinfra.pkgs.visualstudio.com/2692857e-05ef-43b4-ba9c-ccf1c22c437c/_packaging/9387c3aa-d9ad-4513-968c-383f6f7f53b8/pypi/download/onnxruntime-gpu/1.17.1/onnxruntime_gpu-1.17.1-cp312-cp312-manylinux_2_28_x86_64.whl ; platform_system == 'Linux' and python_version == '3.12'",
+    # CUDA 12, Python 3.13, Windows
+    "onnxruntime-gpu @ https://files.pythonhosted.org/packages/c7/87/1361640e9277622591926f84d10fcc289c20be03e1ff5480d66c3cd2402f/onnxruntime_gpu-1.20.1-cp313-cp313-win_amd64.whl ; platform_system == 'Windows' and python_version == '3.13'",
+    # CUDA 12, Python 3.13, Linux
+    "onnxruntime-gpu @ https://files.pythonhosted.org/packages/51/86/de1d7e513e178265e5fac8fd7fd529decd06416cbe316ce77a5b0ff6915b/onnxruntime_gpu-1.20.1-cp313-cp313-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl ; platform_system == 'Linux' and python_version == '3.13'",
 ]
 directml = [
     "onnxruntime-directml"

--- a/src/inference_core_nodes/__init__.py
+++ b/src/inference_core_nodes/__init__.py
@@ -1,6 +1,6 @@
 __all__ = ("__version__", "NODE_CLASS_MAPPINGS", "NODE_DISPLAY_NAME_MAPPINGS")
 
-__version__ = "0.5.0"
+__version__ = "0.5.1"
 
 
 def _get_node_mappings():


### PR DESCRIPTION
Python3.13.12 support was added to StabilityMatrix within the last few releases, but ComfyUI-Inference-Core-Nodes fails to install to the package due to the current dependency requiring versions less than 3.13.

I was able to install ComfyUI-Inference-Core-Nodes after modifying pyproject.toml locally to `<3.14`, and did not have any issues running `install.py` from my 3.13.12 venv after that.