### PR TITLE
Carry pad_weight through Layer Diffuse model patches

### DIFF
--- a/src/inference_core_nodes/__init__.py
+++ b/src/inference_core_nodes/__init__.py
@@ -1,6 +1,6 @@
 __all__ = ("__version__", "NODE_CLASS_MAPPINGS", "NODE_DISPLAY_NAME_MAPPINGS")
 
-__version__ = "0.5.1"
+__version__ = "0.5.2"
 
 
 def _get_node_mappings():

--- a/src/inference_core_nodes/layer_diffuse/layered_diffusion.py
+++ b/src/inference_core_nodes/layer_diffuse/layered_diffusion.py
@@ -323,8 +323,22 @@ class LayeredDiffusionBase:
             model_dir=layer_model_root,
             file_name=self.model_file_name,
         )
+        def pad_diff_weight(v):
+            # ComfyUI reads the second element of a "diff" patch as its options dict, while
+            # to_lora_patch_dict pads the weight list with None. Carry the pad_weight flag
+            # the transparent layer weights need instead.
+            if len(v) == 1:
+                return ("diff", [v[0], {"pad_weight": True}])
+            elif len(v) == 2 and v[0] == "diff":
+                return ("diff", [v[1][0], {"pad_weight": True}])
+            else:
+                return v
+
         layer_lora_state_dict = load_layer_model_state_dict(model_path)
-        layer_lora_patch_dict = to_lora_patch_dict(layer_lora_state_dict)
+        layer_lora_patch_dict = {
+            k: pad_diff_weight(v)
+            for k, v in to_lora_patch_dict(layer_lora_state_dict).items()
+        }
         work_model = model.clone()
         work_model.add_patches(layer_lora_patch_dict, weight)
         return (work_model,)


### PR DESCRIPTION
Fixes [LykosAI/StabilityMatrix#1707](https://github.com/LykosAI/StabilityMatrix/issues/1707) — Inference's **Layer Diffuse (SDXL)** addon failing at the sampler with:

```
TypeError: 'NoneType' object is not subscriptable
  File "comfy/lora.py", line 478, in calculate_weight
    do_pad_weight = len(v) > 1 and v[1]['pad_weight']
```

## Cause

`to_lora_patch_dict` builds each patch as `(patch_type, [None] * 16)` and fills the weights it has, so a single-weight `diff` patch comes out as `("diff", [w, None, …])`. ComfyUI reads element 1 of a `diff` patch as its options dict, hits the `None`, and raises. The transparent layer weights are also larger than the base weights, which is exactly what the `pad_weight` option exists for.

Our vendored `layer_diffuse` predates the fix upstream layerdiffuse made for the same ComfyUI change; this ports it — rebuild the patch dict as `("diff", [w, {"pad_weight": True}])` before `add_patches`.

Only `LayeredDiffusionApply`'s path uses `to_lora_patch_dict`; the attn-sharing path patches differently and is untouched.

Version bumped to 0.5.2.

## After this merges

Stability Matrix pins `Inference_Core_LayeredDiffusionApply` at `>= 0.4.0`, so installs already on 0.5.1 satisfy the constraint and won't be prompted to update. Once 0.5.2 is tagged, a follow-up PR on SM bumps that requirement so affected users get the update offered automatically.