### PR TITLE
Tag and release on version bump

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,55 @@
+name: Release
+
+# Stability Matrix resolves an installed extension's version with
+# `git describe --tags`, so an untagged version bump is invisible to every user
+# (0.5.0 and 0.5.1 shipped that way and nobody was ever offered the update).
+# Tag and release straight off the version bump instead of remembering to.
+
+on:
+  push:
+    branches: [main]
+    paths: ["src/inference_core_nodes/__init__.py"]
+  workflow_dispatch:
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Read package version
+        id: version
+        run: |
+          version=$(sed -n 's/^__version__ = "\(.*\)"$/\1/p' src/inference_core_nodes/__init__.py)
+          if [ -z "$version" ]; then
+            echo "::error::Could not read __version__ from src/inference_core_nodes/__init__.py"
+            exit 1
+          fi
+          echo "version=$version" >> "$GITHUB_OUTPUT"
+          echo "tag=v$version" >> "$GITHUB_OUTPUT"
+          echo "Package version: $version"
+
+      - name: Check whether the tag already exists
+        id: check
+        run: |
+          if git rev-parse "refs/tags/${{ steps.version.outputs.tag }}" >/dev/null 2>&1; then
+            echo "exists=true" >> "$GITHUB_OUTPUT"
+            echo "::notice::${{ steps.version.outputs.tag }} already exists, nothing to release"
+          else
+            echo "exists=false" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Tag and release
+        if: steps.check.outputs.exists == 'false'
+        env:
+          GH_TOKEN: ${{ github.token }}
+          TAG: ${{ steps.version.outputs.tag }}
+        run: |
+          git tag "$TAG"
+          git push origin "$TAG"
+          gh release create "$TAG" --title "$TAG" --generate-notes


### PR DESCRIPTION
The repo has no workflows, and it shows: `0.5.0` and `0.5.1` were both merged without ever being tagged, so the last release is still **v0.4.2 (Feb 2025)**.

That isn't cosmetic. Stability Matrix resolves an installed extension's version with `git describe --tags --abbrev=0` — the newest reachable *tag*, not `__version__` — so every install in the wild reports 0.4.2 no matter how current its code is. An untagged bump reaches nobody, and SM can't offer an update for a version that doesn't exist as a tag.

## What this does

On a push to `main` that touches `src/inference_core_nodes/__init__.py`: read `__version__`, and if `v<version>` isn't already a tag, create it and cut a GitHub release with generated notes. `workflow_dispatch` is there for a manual run.

Skipping when the tag already exists makes re-runs and hand-cut tags harmless, so this can land alongside a manual v0.5.2 without racing it.

Only the version file triggers it, so ordinary merges don't run the job at all.

## Suggested order

1. This PR
2. [#29](https://github.com/LykosAI/ComfyUI-Inference-Core-Nodes/pull/29) (Layer Diffuse fix, bumps to 0.5.2) — merging it cuts **v0.5.2** automatically
3. Un-draft [StabilityMatrix#1352](https://github.com/ionite34/StabilityMatrix/pull/1352), which requires `>= 0.5.2`

Closes nothing by itself, but v0.5.2 releases the fixes already sitting on `main`: #26 (Python 3.13 / onnxruntime-gpu) and #21 (`DwposeDetector` import, fixed by the namespaced controlnet refresh).